### PR TITLE
【Exercises5_6_1】Contactページについて、テストの仕様を変更しました。

### DIFF
--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -27,9 +27,9 @@ describe "Static pages" do
   end
 
   describe "Contact page" do
-      before { visit contact_path }
+    before { visit contact_path }
 
-       it { should have_selector('h1', text: 'Contact') }
-      it { should have_title(full_title('Contact')) }
-    end
+    it { should have_selector('h1', text: 'Contact') }
+    it { should have_title(full_title('Contact')) }
+  end
 end

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -27,9 +27,9 @@ describe "Static pages" do
   end
 
   describe "Contact page" do
-    before { visit contact_path }
+      before { visit contact_path }
 
-    it { should have_content('Contact') }
-    it { should have_title(full_title('Contact')) }
-  end
+       it { should have_selector('h1', text: 'Contact') }
+      it { should have_title(full_title('Contact')) }
+    end
 end


### PR DESCRIPTION
# Rails Tutorial Exercises5_6_1

> http://www.railstutorial.org/book/filling_in_the_layout#sec-layout_exercises
# 自分の考え

Rspec matcher をする際に、have_content メソッドではページ全体からキーワードの有無を確かめるため、フォーカスが広すぎます。そこでhave_selector メソッドを使い、h1タグのみを見てテストをするように改善しました。
以上の内容でMaterにMergeしたいと思っております。
レビューをお願いいたします。
# 動作確認

![2014-07-23 15 02 21](https://cloud.githubusercontent.com/assets/7356977/3669189/468b7406-122f-11e4-8c4d-58fe48620814.png)

@tacahilo @kitak @gs3 @keokent
