### PR TITLE
【Exercises9_6_1】Web上でadmin属性を変更できないことを確認するテストを追加しました。

### DIFF
--- a/spec/requests/user_pages_spec.rb
+++ b/spec/requests/user_pages_spec.rb
@@ -139,5 +139,17 @@ describe "User pages" do
       specify { expect(user.reload.name).to  eq new_name }
       specify { expect(user.reload.email).to eq new_email }
     end
+
+    describe "forbidden attributes" do
+      let(:params) do
+        { user: { admin: true, password: user.password,
+                  password_confirmation: user.password } }
+      end
+      before do
+        sign_in user, no_capybara: true
+        patch user_path(user), params
+      end
+      specify { expect(user.reload).not_to be_admin }
+    end
   end
 end


### PR DESCRIPTION
# Rails Tutorial 【Exercises9_6_1】
## 内容

Web上でadmin属性が変更されては困るため、PATCHリクエストを送ってきたユーザーがadminかどうかを確かめるテストを実装しました。
以下はこのテストが正しいかどうかをチェックした項目となります。 
- [x] 上記の目的を持つテストを追加する
- [x] このテストが正しいのかどうかをチェックするために、ユーザーコントローラーのupdateメソッドにあるユーザーパラメーターにadminを追加し、実際にテストが落ちるかどうかを検証する
- [x] 実際にテストが失敗することを確認したので、先ほどのユーザーパラメーターの中のadminを削除し、再びテストが成功することを確認する
## テストの動作確認
#### 失敗した場合

``` Ruby
* patch% bundle exec rspec spec/                                                                                             (git)-[Exercises9_6_1]
.................................................................................F.....

Failures:

  1) User pages edit forbidden attributes 
     Failure/Error: specify { expect(user.reload).not_to be_admin }
       expected admin? to return false, got true
     # ./spec/requests/user_pages_spec.rb:152:in `block (4 levels) in <top (required)>'

Finished in 3.76 seconds
87 examples, 1 failure

Failed examples:

rspec ./spec/requests/user_pages_spec.rb:152 # User pages edit forbidden attributes 
Randomized with seed 48490
```
#### 成功した場合

``` Ruby
% bundle exec rspec spec/                                                                                             (git)-[Exercises9_6_1]
.......................................................................................

Finished in 3.74 seconds
87 examples, 0 failures

Randomized with seed 41121
```
## 演習内容

> http://www.railstutorial.org/book/updating_and_deleting_users#sec-updating_deleting_exercises

---

この内容でMasterにマージしたいと思います。
レビューをお願いいたします。

@tacahilo @kitak @gs3 @keokent 
