### PR TITLE
【Exercises9_6_2】target=”_blank” を使うことにより、Gravaterのchangeリンクから別タブに移動できるように実装しました。

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -22,6 +22,6 @@
     <% end %>
 
     <%= gravatar_for @user %>
-    <a href="http://gravatar.com/emails">change</a>
+    <%= link_to "change", "http://gravatar.com/emails", :target=>["_blank"] %>
   </div>
 </div>


### PR DESCRIPTION
# Rails Tutorial 【Exercises9_6_2】
## 内容

target=”_blank” を使うことにより、Gravaterのchangeリンクから別タブにページ遷移するように実装しました。
以下の手順により、この実装が正しく動作しているかをチェックしました。
- [x] 全体テストでGreenを確認する
- [x] ローカルサーバー上の Update your profile ページにあるchangeリンクを押すと別タブにページ遷移することを確認する
## テスト結果

全体テストでGreenを確認しました。

``` Ruby
% bundle exec rspec spec/                                                                                             (git)-[Exercises9_6_2]
......................................................................................

Finished in 3.6 seconds
86 examples, 0 failures

Randomized with seed 59485

```
## 演習内容

> http://www.railstutorial.org/book/updating_and_deleting_users#sec-updating_deleting_exercises

---

この内容でMasterにマージしたいと思います。
レビューをお願いいたします。

@tacahilo @kitak @gs3 @keokent 
