### PR TITLE
[Exercises9_6_3] Sign in していないユーザーに対し、“Profile”,“Settings” のリンクタグが見えないことを確認するテストを追加しました。

### DIFF
--- a/spec/requests/authentication_pages_spec.rb
+++ b/spec/requests/authentication_pages_spec.rb
@@ -9,6 +9,8 @@ describe "Authentication" do
 
     it { should have_content('Sign in') }
     it { should have_title('Sign in') }
+    it { should_not have_link('Profile') }
+    it { should_not have_link('Settings') }
   end
 
   describe "signin" do
@@ -19,6 +21,8 @@ describe "Authentication" do
 
       it { should have_title('Sign in') }
       it { should have_error_message }
+      it { should_not have_link('Profile') }
+      it { should_not have_link('Settings') }
 
       describe "after visiting another page" do
         before { click_link "Home" }


### PR DESCRIPTION
# Rails Tutorial 【Exercises9_6_3】
## 内容

サインインしていないユーザーに対し、“Profile”,“Settings” のリンクタグが見えないことを確認するテストを追加しました。
最初にサインインページに訪れた場合と、サインインに失敗して再度サインインページにリダイレクトされた場合についてのテストとなります。
以下の手順により、この実装が正しく動作しているかをチェックしました。
- [x] 全体テストでGreenを確認する
- [x] ローカルサーバー上で、サインインページにアクセスした場合に“Profile”,“Settings” のリンクタグが見えないことを確認する
- [x] ローカルサーバー上で、サインインに失敗してリダイレクトされた場合に“Profile”,“Settings” のリンクタグが見えないことを確認する
## テスト結果

全体テストでGreenを確認しました。

``` Ruby
% bundle exec rspec spec/                                                                                             (git)-[Exercises9_6_3]
..........................................................................................

Finished in 3.69 seconds
90 examples, 0 failures

Randomized with seed 16257
```
## ローカルサーバーチェック
#### 最初にサインインをする場合

![2014-09-04 19 01 03](https://cloud.githubusercontent.com/assets/7356977/4147772/1225a9de-341c-11e4-9be2-7641e5ba2681.png)
#### サインインに失敗した場合

![2014-09-04 19 10 00](https://cloud.githubusercontent.com/assets/7356977/4147773/16329398-341c-11e4-9c16-332725df7e58.png)
## 演習内容

> http://www.railstutorial.org/book/updating_and_deleting_users#sec-updating_deleting_exercises

---

この内容でMasterにマージしたいと思います。
レビューをお願いいたします。

@tacahilo @kitak @gs3 @keokent 
