### PR TITLE
【Exercises9_6_6】サインイン済みユーザーがnewやcreateアクションを行なった際にルートURLにリダイレクトする機能を追加しま...

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,8 @@ class UsersController < ApplicationController
   before_action :signed_in_user, only: [:index, :edit, :update, :destroy]
   before_action :correct_user,   only: [:edit, :update]
   before_action :admin_user,     only: :destroy
-
+  before_action :signed_in_dummyuser, only: [:new, :create]
+  
   def index
     @users = User.paginate(page: params[:page])
   end
@@ -15,7 +16,7 @@ class UsersController < ApplicationController
     @user = User.new
   end
 
-  def create
+  def create    
     @user = User.new(user_params)
     if @user.save
       sign_in @user
@@ -52,6 +53,12 @@ class UsersController < ApplicationController
     end
 
     # Before filters
+   
+    def signed_in_dummyuser
+      if signed_in?
+        redirect_to(root_url) 
+      end
+    end
 
     def signed_in_user
       unless signed_in?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   before_action :signed_in_user, only: [:index, :edit, :update, :destroy]
   before_action :correct_user,   only: [:edit, :update]
   before_action :admin_user,     only: :destroy
-  before_action :signed_in_dummyuser, only: [:new, :create]
+  before_action :redirect_for_signed_in_user, only: [:new, :create]
   
   def index
     @users = User.paginate(page: params[:page])
@@ -16,7 +16,7 @@ class UsersController < ApplicationController
     @user = User.new
   end
 
-  def create    
+  def create
     @user = User.new(user_params)
     if @user.save
       sign_in @user
@@ -54,9 +54,9 @@ class UsersController < ApplicationController
 
     # Before filters
    
-    def signed_in_dummyuser
+    def redirect_for_signed_in_user
       if signed_in?
-        redirect_to(root_url) 
+        redirect_to(root_url)
       end
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
-  before_action :signed_in_user, only: [:index, :edit, :update, :destroy]
-  before_action :correct_user,   only: [:edit, :update]
-  before_action :admin_user,     only: :destroy
+  before_action :signed_in_user,              only: [:index, :edit, :update, :destroy]
+  before_action :correct_user,                only: [:edit, :update]
+  before_action :admin_user,                  only: :destroy
   before_action :redirect_for_signed_in_user, only: [:new, :create]
   
   def index


### PR DESCRIPTION
# Rails Tutorial 【Exercises9_6_6】
## 内容

サインイン済みユーザーがnewやcreateアクションを行う必要はないので、もしもそのようなアクションが実行された際にはルートURLにリダイレクトさせる必要があります。
そのため、以下の手順の通りに機能を実装しました。
- [x] サインイン済みユーザーがnewやcreateアクションを行なった際に、ルートURLにリダイレクトする機能を追加する
- [x] ローカルサーバー上での動作確認をする
- [x] テストを行う
## テスト結果

全体テストでGreenを確認しました。

``` Ruby
% bundle exec rspec spec/                                                                                                                                                                                              (git)-[Exercises9_6_6]
...........................................................................................

Finished in 4.25 seconds
91 examples, 0 failures

Randomized with seed 25418

```
## 演習内容

> http://www.railstutorial.org/book/updating_and_deleting_users#sec-updating_deleting_exercises

---

この内容でMasterにマージしたいと思います。
レビューをお願いいたします。

@tacahilo @kitak @gs3 @keokent 
