### PR TITLE
【Exercises10_5_6】ユーザープロフィールとホームのページについて、micropostの文字数が長すぎてしまうと画面からはみでてしま...

### DIFF
--- a/app/helpers/indention_helper.rb
+++ b/app/helpers/indention_helper.rb
@@ -1,4 +1,4 @@
-module MicropostsHelper
+module IndentionHelper
 
   def wrap(content)
     sanitize(raw(content.split.map{ |s| wrap_long_string(s) }.join(' ')))
@@ -6,7 +6,7 @@ module MicropostsHelper
 
   private
 
-    def wrap_long_string(text, max_width = 30)
+    def wrap_long_string(text, max_width = 25)
       zero_width_space = "&#8203;"
       regex = /.{1,#{max_width}}/
       (text.length < max_width) ? text :

--- a/app/helpers/microposts_helper.rb
+++ b/app/helpers/microposts_helper.rb
@@ -1,0 +1,15 @@
+module MicropostsHelper
+
+  def wrap(content)
+    sanitize(raw(content.split.map{ |s| wrap_long_string(s) }.join(' ')))
+  end
+
+  private
+
+    def wrap_long_string(text, max_width = 30)
+      zero_width_space = "&#8203;"
+      regex = /.{1,#{max_width}}/
+      (text.length < max_width) ? text :
+                                  text.scan(regex).join(zero_width_space)
+    end
+end

--- a/app/views/microposts/_micropost.html.erb
+++ b/app/views/microposts/_micropost.html.erb
@@ -1,5 +1,5 @@
 <li>
-  <span class="content"><%= micropost.content %></span>
+  <span class="content"><%= wrap(micropost.content) %></span>
   <span class="timestamp">
     Posted <%= time_ago_in_words(micropost.created_at) %> ago.
   </span>

--- a/app/views/shared/_feed_item.html.erb
+++ b/app/views/shared/_feed_item.html.erb
@@ -3,7 +3,7 @@
     <span class="user">
       <%= link_to feed_item.user.name, feed_item.user %>
     </span>
-    <span class="content"><%= feed_item.content %></span>
+    <span class="content"><%= wrap(feed_item.content) %></span>
     <span class="timestamp">
       Posted <%= time_ago_in_words(feed_item.created_at) %> ago.
     </span>

--- a/app/views/shared/_user_info.html.erb
+++ b/app/views/shared/_user_info.html.erb
@@ -1,6 +1,6 @@
 <%= link_to gravatar_for(current_user, size: 52), current_user %>
 <h1>
-  <%= current_user.name %>
+  <%= wrap(current_user.name) %>
 </h1>
 <span>
   <%= link_to "view my profile", current_user %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,7 +4,7 @@
     <section>
       <h1>
         <%= gravatar_for @user %>
-        <%= @user.name %>
+        <%= wrap(@user.name) %>
       </h1>
     </section>
   </aside>


### PR DESCRIPTION
# Rails Tutorial 【Exercises10_5_6】
## 内容

大きく分けて２つの機能を追加します。
- ユーザープロフィールとホームのページについて、micropostの文字数が長すぎてしまうと画面からはみでてしまう仕様になっているため、30文字で自動的に改行して表示されるように修正する
- XSS脆弱性対策として `sanitize`を扱うことにより、セキュリティを強化する

(commitの粒度を考えれば２つのcommitに分けるべきでしたが、気づいたのはpushしてからでした。次回から気をつけます。)
## 表示結果
#### ユーザープロフィールページについて
###### 変更前

![2014-10-08 18 34 20](https://cloud.githubusercontent.com/assets/7356977/4557686/19b4158a-4ed6-11e4-973b-a4fad780bc5e.png)
###### 変更後

![2014-10-08 19 34 15](https://cloud.githubusercontent.com/assets/7356977/4557747/bdc77f2c-4ed6-11e4-86a5-ea4de61e3cc8.png)
#### ホームページについて
###### 変更前

![2014-10-08 18 32 25](https://cloud.githubusercontent.com/assets/7356977/4557687/1c5efc78-4ed6-11e4-89d5-947557c929a9.png)
###### 変更後

![2014-10-08 19 32 22](https://cloud.githubusercontent.com/assets/7356977/4557760/db665bfc-4ed6-11e4-8530-ba0144f3f5a5.png)
## 演習内容

> https://www.railstutorial.org/book/user_microposts#sec-micropost_exercises

---

レビューをお願いいたします。

@tacahilo @kitak @gs3 @keokent 
