### PR TITLE
【Exercises11_5_1】特定のユーザーが削除された場合、そのユーザーに紐づくリレーションシップのレコードも同時に削除することを確かめる...

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -176,6 +176,37 @@ describe User do
     end
   end
 
+  describe "dependent::destroy"  do
+    let(:other_user) { FactoryGirl.create(:user) }
+    before do
+      @user.save
+    end
+
+    context "When following other_user" do
+      it "Relationship record should also delete When deleted other_user" do
+        @user.follow!(other_user)
+        followed_users = @user.followed_users.to_a
+        other_user.destroy
+        expect(followed_users).not_to be_empty
+        followed_users.each do |followed|
+          expect(Relationship.where(followed_id: followed.id )).to be_empty
+        end
+      end
+    end
+
+    context "When following other_user" do
+      it "reverce Relationship record should also delete When deleted other_user" do
+        other_user.follow!(@user)
+        followers = @user.followers.to_a
+        other_user.destroy
+        expect(followers).not_to be_empty
+        followers.each do |follower|
+          expect(Relationship.where(follower_id: follower.id )).to be_empty
+        end
+      end
+    end
+  end
+
   describe "following" do
     let(:other_user) { FactoryGirl.create(:user) }
     before do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -194,7 +194,7 @@ describe User do
       end
     end
 
-    context "When following other_user" do
+    context "When followed by other_user" do
       it "reverce Relationship record should also delete When deleted other_user" do
         other_user.follow!(@user)
         followers = @user.followers.to_a


### PR DESCRIPTION
# Rails Tutorial 【Exercises11_5_1】
## 内容

特定のユーザーが削除された場合、そのユーザーに紐づくリレーションシップテーブルのレコードも同時に削除されている必要があるため、それを確かめるテストを追加しました。

具体的には、ユーザーモデルに記述した`dependent::destroy`についてのテストになります。

以下の２つの場合について実装しました。
- [x] 特定のユーザーをフォローしていた場合
- [x] 特定のユーザーからフォローされていた場合
## 演習内容

> https://www.railstutorial.org/book/following_users#sec-following_exercises
> ---

レビューをお願いいたします:bow:

@adarapata @kurotaky @2get @tacahilo @kitak @gs3 @keokent 
