### PR TITLE
【Exercieses11_5_4】プロファイルページ上のフォローしているユーザーとフォロワーの統計情報をテストする

### DIFF
--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -45,6 +45,19 @@ describe "Static pages" do
     end
   end
 
+  describe "follower/following counts about Profile page" do
+    let(:user) { FactoryGirl.create(:user) }
+    let(:other_user) { FactoryGirl.create(:user) }
+    before do
+      sign_in user
+      other_user.follow!(user)
+      visit user_path(user)
+    end
+
+    it { should have_link("0 following", href: following_user_path(user)) }
+    it { should have_link("1 followers", href: followers_user_path(user)) }
+  end
+
   describe "Help page" do
     before { visit help_path }
 


### PR DESCRIPTION
# Rails Tutorial 【Exercises11_5_4】
## 内容

ホームページ上におけるフォローしているユーザーとフォロワーの統計情報のテストはTutorial上で実装しましたが、プロファイルページ上のフォローしているユーザーとフォロワーの統計情報のテストは実装していませんでした。
したがって以下のプロセスによりそのテストを表現し、実装しました。
- [x] other_userにフォローされる
- [x] followingの数が`0`であることを確認する
- [x] followersの数が`1`に増えていることを確認する
## 演習内容

> https://www.railstutorial.org/book/following_users#sec-following_exercises
> ---

レビューをお願いいたします:bow:

@adarapata @kurotaky @2get @tacahilo @kitak @gs3 @keokent 
